### PR TITLE
poll: clientside filtering

### DIFF
--- a/poll/forms.py
+++ b/poll/forms.py
@@ -101,6 +101,13 @@ class PollForm(forms.ModelForm):
                 self.initial['choices'] = [v.item.pk for v in self.votes]
 
     @property
+    def tags(self):
+        tags = list(self.instance.tags.names())
+        if not self.user_voted:
+            tags.append("Unbeantwortet")
+        return tags
+
+    @property
     def user_voted(self):
         return any([v.user == self.user for v in self.votes])
 

--- a/poll/forms.py
+++ b/poll/forms.py
@@ -160,4 +160,4 @@ class PollForm(forms.ModelForm):
                 vote.save()
         else:
             raise RuntimeError("Unknown Voting")
-        
+

--- a/poll/models.py
+++ b/poll/models.py
@@ -169,6 +169,29 @@ class Poll(models.Model):
                     ret += [(item, percent, percent)]
         return ret
 
+    def get_result_data(self, show_results):
+        results = {'totalVotes': self.vote_count, 'options': [], 'type': self.poll_type}
+        if show_results and not self.is_text:
+            item: Item
+            for (item, val, _) in self.results:
+                option = {
+                    'value': item.value,
+                    'count': val if self.is_prio else item.vote_count
+                }
+                if self.poll_type == Poll.YESNONONE:
+                    count = [0, 0, 0]
+                    for v in self.votes:
+                        i = 2
+                        if v.text == 'ja':
+                            i = 0
+                        if v.text == 'nein':
+                            i = 1
+                        count[i] = count[i] + 1
+                    option['count'] = count
+                results['options'].append(option)
+
+        return results
+
     @property
     def votes(self):
         return Vote.objects \

--- a/poll/static/poll.js
+++ b/poll/static/poll.js
@@ -126,7 +126,6 @@ function showAlert(message, extraClasses) {
 
 function applyFilters() {
 
-    console.log("filterIds: ", filterIds);
 
     updateUrlSearchParams();
 
@@ -175,7 +174,6 @@ function applyFilters() {
         clearFilterButton.style.display = "none";
     else
         clearFilterButton.style.removeProperty("display");
-    console.log("filterWords: ", filterWords);
 
     questionsToDisplay
         .forEach(card => { card.style.removeProperty("display"); });
@@ -325,6 +323,11 @@ function clearFilters(event) {
     }
 }
 
+function updateSearchFilter(e) {
+    filterQuery = e.target.value;
+    applyFilters();
+}
+
 function updateUrlSearchParams() {
 
     let searchParams = new URLSearchParams(window.location.search);
@@ -356,7 +359,7 @@ function updateUrlSearchParams() {
 
 let urlParams = new URLSearchParams(window.location.search);
 let tagFilters = urlParams.getAll("tag");
-let filterQuery = urlParams.get("q") ?? ""
+let filterQuery = urlParams.get("q") ?? "";
 let filterIds = urlParams.getAll("p")
     .map(s => {
         try {
@@ -389,12 +392,11 @@ document.querySelectorAll(".tag-filter-button").forEach(btn => {
     btn.addEventListener("click", e => { toggleTagFilter(e, btn.getAttribute("data-tag"))})
 });
 
-document.querySelector(".search-form").addEventListener("submit", (e) => {
-    e.preventDefault();
-    let data = new FormData(e.target);
-    filterQuery = data.get("q");
-    applyFilters();
-});
+let searchForm = document.querySelector(".search-form");
+let searchField = searchForm.querySelector("#filter-q");
+searchForm.querySelector("button[type=submit]").style.display = "none";
+searchField.addEventListener("input", updateSearchFilter);
+searchField.addEventListener("propertychange", updateSearchFilter);
 
 if (filterQuery.length !== 0 || tagFilters.length !== 0 || filterIds.length !== 0)
     applyFilters();

--- a/poll/static/poll.js
+++ b/poll/static/poll.js
@@ -66,6 +66,14 @@ async function showAlert(message, extraClasses) {
     }, 10000);
 }
 
+function findParent(el, classList) {
+    while (el !== null && !classList.every(cls => el.classList.contains(cls))) {
+        el = el.parentNode;
+    }
+
+    return el;
+}
+
 async function submitForm(e) {
     e.preventDefault();
     let form = e.target;
@@ -114,10 +122,18 @@ async function submitForm(e) {
         );
         console.log("Data submitted successfully.");
         await showAlert(responseData?.message ?? "Deine Stimme wurde gespeichert.", ["alert-success"]);
+        findParent(form, ['question-card']).classList.remove("border-danger");
+        findParent(form, ['question-card']).classList.add("border-success");
+        form.querySelector("button[type=submit]").classList.remove("btn-info", "btn-danger");
+        form.querySelector("button[type=submit]").classList.add("btn-success");
     } else {
         console.warn(`Failed to submit data! Reason: ${responseData?.error ?? "unexpected error"}`);
         await showAlert(`Beim Speichern deiner Stimme trat ein Fehler auf! `
             + `Grund: ${responseData?.error ?? "unexpected error"}`, ["alert-danger"]);
+        findParent(form, ['question-card']).classList.remove("border-success");
+        findParent(form, ['question-card']).classList.add("border-danger");
+        form.querySelector("button[type=submit]").classList.remove("btn-info", "btn-success");
+        form.querySelector("button[type=submit]").classList.add("btn-danger");
     }
 
     form.querySelectorAll("button[type=submit]").forEach((btn) => {

--- a/poll/static/poll.js
+++ b/poll/static/poll.js
@@ -8,24 +8,30 @@ async function updatePollSummary(formContainer, pollResults) {
         return;
 
     let resultOptions = formContainer.querySelectorAll(".poll-result li");
+    if (pollResults === null) {
+        resultContainer.style.visibility = "hidden";
+        return
+    }
 
+    resultContainer.style.visibility = "visible";
     resultContainer.querySelector(".total-vote-count").innerText = pollResults["totalVotes"]
     let pollIter = pollResults["options"].values();
     resultOptions.forEach(el => {
         let nextItem = pollIter.next();
         let {value: optionValue, count: optionCount} = nextItem.value;
-        let optionPercentage;
+        let optionPercentage = 0;
 
         if (pollResults["type"] === "Y3") {
             let optionCountDetails = optionCount;
             optionCount = optionCountDetails.reduce((a, b) => a + b);
             el.querySelector(".option-details").innerText = `Ja: ${optionCountDetails[0]}, `
                 + `Nein: ${optionCountDetails[1]}, Enthaltung: ${optionCountDetails[2]}`;
-            optionPercentage = 100 * optionCountDetails[0] / pollResults["totalVotes"];
+            if (pollResults["totalVotes"] !== 0)
+                optionPercentage = 100 * optionCountDetails[0] / pollResults["totalVotes"];
         }
         else if (pollResults["type"] === "PR")
             optionPercentage = 100 * optionCount / 5.0;
-        else
+        else if (pollResults["totalVotes"] !== 0)
             optionPercentage = 100 * optionCount / pollResults["totalVotes"];
 
         el.querySelectorAll(".option-value").forEach((container) => {
@@ -87,8 +93,9 @@ async function submitForm(e) {
             data[key] = formData.get(key);
     }
     let dataJson = JSON.stringify(data);
+    let submitButtons = form.querySelectorAll("button.submit-button");
 
-    form.querySelectorAll("button[type=submit]").forEach((btn) => {
+    submitButtons.forEach((btn) => {
         btn.setAttribute('data-text', btn.innerText);
         btn.innerText =". . .";
         btn.setAttribute("disabled", "disabled");
@@ -114,6 +121,7 @@ async function submitForm(e) {
         console.warn("Did not receive a valid JSON response");
     }
 
+    let questionCard = findParent(form, ['question-card']);
     if (response.ok && responseData !== null) {
         let formId = form.getAttribute("data-form-id");
         await updatePollSummary(
@@ -122,27 +130,110 @@ async function submitForm(e) {
         );
         console.log("Data submitted successfully.");
         await showAlert(responseData?.message ?? "Deine Stimme wurde gespeichert.", ["alert-success"]);
-        findParent(form, ['question-card']).classList.remove("border-danger");
-        findParent(form, ['question-card']).classList.add("border-success");
-        form.querySelector("button[type=submit]").classList.remove("btn-info", "btn-danger");
-        form.querySelector("button[type=submit]").classList.add("btn-success");
+        setHighlightMode([questionCard], 'border', 'success');
+        setHighlightMode(submitButtons, 'btn', 'success');
+        let badgeContainer = questionCard.querySelector(".poll-badges");
+        if (badgeContainer.querySelector(".success-badge") === null) {
+            let successBadge = document.createElement("span");
+            successBadge.classList.add("badge", "badge-info", "success-badge");
+            successBadge.innerText = "Abgestimmt";
+            badgeContainer.insertBefore(successBadge, badgeContainer.firstChild);
+        }
+
+        form.querySelectorAll("button.retract-button").forEach(btn => {
+            btn.removeAttribute("disabled");
+        });
     } else {
         console.warn(`Failed to submit data! Reason: ${responseData?.error ?? "unexpected error"}`);
         await showAlert(`Beim Speichern deiner Stimme trat ein Fehler auf! `
             + `Grund: ${responseData?.error ?? "unexpected error"}`, ["alert-danger"]);
-        findParent(form, ['question-card']).classList.remove("border-success");
-        findParent(form, ['question-card']).classList.add("border-danger");
-        form.querySelector("button[type=submit]").classList.remove("btn-info", "btn-success");
-        form.querySelector("button[type=submit]").classList.add("btn-danger");
+        setHighlightMode([questionCard], 'border', 'danger');
+        setHighlightMode(submitButtons, 'btn', 'danger');
     }
 
-    form.querySelectorAll("button[type=submit]").forEach((btn) => {
+    submitButtons.forEach((btn) => {
         btn.innerText = btn.getAttribute('data-text');
         btn.removeAttribute("disabled");
     });
 
 }
 
+async function retractVote(e, form) {
+    if (e.target.hasAttribute("disabled"))
+        return;
+    e.preventDefault();
+    let formData = new FormData(form);
+    let response = await fetch(form.action, {
+        method: 'DELETE',
+        mode: 'same-origin',
+        cache: 'no-cache',
+        credentials: 'same-origin',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': formData.get('csrfmiddlewaretoken')
+        },
+        redirect: 'follow',
+    })
+    let responseData;
+    try {
+        responseData = await response.json();
+    } catch (e) {
+        responseData = null;
+        console.warn("Did not receive a valid JSON response");
+    }
+    let questionCard = findParent(form, ['question-card']);
+    let submitButtons = form.querySelectorAll("button.submit-button");
+    let retractButtons = form.querySelectorAll("button.retract-button");
+
+    if (response.ok && responseData !== null) {
+        let formId = form.getAttribute("data-form-id");
+        await updatePollSummary(
+            document.getElementById(`form-container-${formId}`),
+            responseData["pollResults"]
+        );
+        console.log("Data submitted successfully.");
+        form.reset();
+        await showAlert(responseData?.message ?? "Deine Stimme wurde gelöscht.", ["alert-success"]);
+        setHighlightMode([questionCard], 'border', null);
+        setHighlightMode(submitButtons, 'btn', 'info');
+        retractButtons.forEach(btn => {
+           btn.setAttribute("disabled", "disabled");
+        });
+        let badge = questionCard.querySelector(".poll-badges .success-badge");
+        if (badge !== null) {
+            badge.parentNode.removeChild(badge);
+        }
+    } else {
+        console.warn(`Failed to submit data! Reason: ${responseData?.error ?? "unexpected error"}`);
+        await showAlert(`Beim Löschen deiner Stimme trat ein Fehler auf! `
+            + `Grund: ${responseData?.error ?? "unexpected error"}`, ["alert-danger"]);
+        setHighlightMode([questionCard], 'border', 'danger');
+        setHighlightMode(submitButtons, 'btn', 'danger');
+    }
+}
+
+function setHighlightMode(elements, prefix, mode) {
+
+    let modes = ["info", "success", "danger"]
+
+    elements.forEach(btn => {
+        modes.forEach(m => {
+            btn.classList.remove(`${prefix}-${m}`);
+        });
+        if (mode !== null)
+            btn.classList.add(`${prefix}-${mode}`);
+    })
+}
+
 document.querySelectorAll("form.poll-form").forEach((form) => {
     form.addEventListener("submit", submitForm);
 });
+
+document.querySelectorAll(".question-card").forEach(card => {
+    let form = card.querySelector("form.poll-form");
+    form.querySelectorAll("button.retract-button").forEach(btn => {
+        if (card.querySelector(".poll-badges .success-badge") === null)
+            btn.setAttribute("disabled", "disabled");
+        btn.addEventListener("click", async e => { await retractVote(e, form); });
+    })
+})

--- a/poll/static/poll.js
+++ b/poll/static/poll.js
@@ -225,6 +225,107 @@ function setHighlightMode(elements, prefix, mode) {
     })
 }
 
+function toggleTagFilter(event, tag) {
+    event.preventDefault();
+
+    if (tagFilters.includes(tag))
+        tagFilters.splice(tagFilters.indexOf(tag), 1);
+    else
+        tagFilters.push(tag);
+    applyFilters();
+}
+
+function clearFilters(event, tag) {
+    event.preventDefault();
+
+    if (tagFilters.length !== 0 || filterQuery.length > 0) {
+        tagFilters = [];
+        filterQuery = "";
+        document.querySelector(".search-form").reset();
+        applyFilters();
+    }
+}
+
+function updateUrlSearchParams() {
+
+    let searchParams = new URLSearchParams(window.location.search);
+
+    let tagParams = searchParams.getAll("tag");
+    searchParams.delete("tag")
+    tagFilters.forEach(tag => {
+        if (!tagParams.includes(tag))
+            searchParams.append("tag", tag);
+    })
+
+    searchParams.set("q", filterQuery);
+
+    if (searchParams !== window.location.searchParams) {
+        let url = new URL(window.location.href);
+        url.search = searchParams;
+        window.history.pushState({}, "", url);
+    }
+}
+
+function applyFilters() {
+
+    updateUrlSearchParams();
+
+    let filterWords = [].concat(tagFilters, filterQuery.split(" ")).filter(s => s.length !== 0);
+
+    function shouldDisplayQuestion(q) {
+        return (
+            tagFilters.length === 0 || q.getAttribute("data-taglist")
+                ?.split(" ")
+                .some(tag => tagFilters.includes(tag))
+        ) && (
+            filterQuery.length === 0
+            || filterWords.some(word => q.getAttribute("data-description")?.toLowerCase().indexOf(word.toLowerCase()) !== -1)
+            || filterWords.some(word => q.getAttribute("data-question")?.toLowerCase().indexOf(word.toLowerCase()) !== -1)
+        )
+    }
+
+    let questions = Array.from(document.querySelectorAll(".question-card"));
+    let questionsToDisplay = questions
+        .filter(q => shouldDisplayQuestion(q));
+    let questionsToHide = questions
+        .filter(q => !shouldDisplayQuestion(q));
+
+    let filterButtons = Array.from(document.querySelectorAll(".tag-filter-button"));
+
+    filterButtons
+        .filter(btn => tagFilters.includes(btn.getAttribute("data-tag")))
+        .forEach(btn => {
+            btn.classList.remove("btn-secondary");
+            btn.classList.add("btn-warning");
+            btn.innerText = `${btn.getAttribute("data-tag")} (x)`
+        })
+    filterButtons
+        .filter(btn => !tagFilters.includes(btn.getAttribute("data-tag")))
+        .forEach(btn => {
+            btn.classList.remove("btn-warning");
+            btn.classList.add("btn-secondary");
+            btn.innerText = `${btn.getAttribute("data-tag")}`
+        })
+    let clearFilterButton = document.querySelector(".clear-filter-button");
+
+    if (filterWords.length === 0)
+        clearFilterButton.style.display = "none";
+    else
+        clearFilterButton.style.removeProperty("display");
+    console.log("filterWords: ", filterWords);
+
+    questionsToDisplay
+        .forEach(card => { card.style.removeProperty("display"); });
+    questionsToHide
+        .forEach(card => { card.style.display = "none"; });
+}
+
+/// ENTRYPOINT ///
+
+let urlParams = new URLSearchParams(window.location.search);
+let tagFilters = urlParams.getAll("tag");
+let filterQuery = urlParams.get("q") ?? "";
+
 document.querySelectorAll("form.poll-form").forEach((form) => {
     form.addEventListener("submit", submitForm);
 });
@@ -236,4 +337,19 @@ document.querySelectorAll(".question-card").forEach(card => {
             btn.setAttribute("disabled", "disabled");
         btn.addEventListener("click", async e => { await retractVote(e, form); });
     })
+})
+
+
+document.querySelector(".clear-filter-button")
+    .addEventListener("click", e => { clearFilters(e) });
+
+document.querySelectorAll(".tag-filter-button").forEach(btn => {
+    btn.addEventListener("click", e => { toggleTagFilter(e, btn.getAttribute("data-tag"))})
+});
+
+document.querySelector(".search-form").addEventListener("submit", (e) => {
+    e.preventDefault();
+    let data = new FormData(e.target);
+    filterQuery = data.get("q");
+    applyFilters();
 })

--- a/poll/templates/poll/view.html
+++ b/poll/templates/poll/view.html
@@ -69,9 +69,9 @@
              {% if not search_p and not search_q and not search_tag %}style="display: none;"{% endif %}>Alle anzeigen</a>
         </div>
         <div class="col-sm-12 form-group row mt-4">
-          <label class="col-sm-2 col-form-label" for="q"><strong>Freitextsuche:</strong></label>
+          <label class="col-sm-2 col-form-label" for="filter-q"><strong>Freitextsuche:</strong></label>
           <div class="col-sm-8">
-            <input type="text" class="form-control mb-2 mr-sm-2" id="q" name="q" value="{{search_q}}"/>
+            <input type="text" class="form-control mb-2 mr-sm-2" id="filter-q" name="q" value="{{search_q}}"/>
           </div>
           <button type="submit" class="btn btn-primary">Los</button>
           <input type="hidden" name="tag" value="{{ search_tag }}"/>

--- a/poll/templates/poll/view.html
+++ b/poll/templates/poll/view.html
@@ -87,7 +87,7 @@
 {% endif %}
 
 {% for form in poll_forms %}
-  <div class="card card-light-bg mb-3" style="break-inside: avoid;">
+  <div class="question-card card card-light-bg mb-3 border" style="break-inside: avoid;">
     <h3 id="poll{{form.instance.id}}" class="card-header">
       {{form.instance.number}}. {{form.instance.question}}
       {% if not print_mode %}

--- a/poll/templates/poll/view.html
+++ b/poll/templates/poll/view.html
@@ -1,6 +1,7 @@
 
 {% extends "base.html" %}
 
+{% load static %}
 {% load bootstrap4 %}
 {% load markdownify %}
 
@@ -49,7 +50,7 @@
   {% if not print_mode %}
   <p class="hide-in-iframe">
     <hr/>
-    <form class="hide-in-iframe" method="GET" action="{% url 'poll:view' poll_collection.pk %}">
+    <form class="hide-in-iframe search-form" method="GET" action="{% url 'poll:view' poll_collection.pk %}">
       <div class="row">
         <div class="col-sm-2">
           <strong>Schlagwörter-Filter:</strong>
@@ -58,15 +59,14 @@
           {% if available_tags %}
             {% for tag in available_tags%}
               {% if tag == search_tag %}
-                <a href="?q={{search_q}}" class="mb-2 btn btn-warning">{{tag}} (x)</a>
+                <a href="?q={{search_q}}" class="mb-2 btn btn-warning tag-filter-button" data-tag="{{tag}}">{{tag}} (x)</a>
               {% else %}
-                <a href="?q={{search_q}}&tag={{tag}}" class="mb-2 btn btn-secondary">{{tag}}</a>
+                <a href="?q={{search_q}}&tag={{tag}}" class="mb-2 btn btn-secondary tag-filter-button" data-tag="{{tag}}">{{tag}}</a>
               {% endif %}
             {% endfor %}
           {% endif %}
-          {% if search_p or search_q or search_tag%}
-            <a href="?search_p=" class="btn mb-2 btn-warning">Alle anzeigen</a>
-          {% endif %}
+          <a href="?search_p=" class="btn mb-2 btn-warning clear-filter-button"
+             {% if not search_p and not search_q and not search_tag %}style="display: none;"{% endif %}>Alle anzeigen</a>
         </div>
         <div class="col-sm-12 form-group row mt-4">
           <label class="col-sm-2 col-form-label" for="q"><strong>Freitextsuche:</strong></label>
@@ -87,7 +87,12 @@
 {% endif %}
 
 {% for form in poll_forms %}
-  <div class="question-card card card-light-bg mb-3 border {% if form.user_voted %}border-success{% endif %}" style="break-inside: avoid;">
+  <div class="question-card card card-light-bg mb-3 border {% if form.user_voted %}border-success{% endif %}"
+       data-taglist="{{ form.tags|join:' ' }}"
+       data-description="{{ form.instance.description }}"
+       data-question="{{ form.instance.question }}"
+       data-dirty="false"
+       style="break-inside: avoid;">
     <h3 id="poll{{form.instance.id}}" class="card-header">
       {{form.instance.number}}. {{form.instance.question}}
       {% if not print_mode %}
@@ -195,9 +200,9 @@
   {% endblock %}
 
 {% block javascript %}
-<script type="application/javascript" src="/static/poll.js"></script>
+<script type="application/javascript" src="{% static 'poll.js' %}"></script>
 {% endblock %}
 
 {% block css %}
-  <link rel="stylesheet" href="/static/poll.css"/>
+  <link rel="stylesheet" href="{% static 'poll.css' %}"/>
 {% endblock %}

--- a/poll/templates/poll/view.html
+++ b/poll/templates/poll/view.html
@@ -87,14 +87,14 @@
 {% endif %}
 
 {% for form in poll_forms %}
-  <div class="question-card card card-light-bg mb-3 border" style="break-inside: avoid;">
+  <div class="question-card card card-light-bg mb-3 border {% if form.user_voted %}border-success{% endif %}" style="break-inside: avoid;">
     <h3 id="poll{{form.instance.id}}" class="card-header">
       {{form.instance.number}}. {{form.instance.question}}
       {% if not print_mode %}
         <a href="#poll{{form.instance.id}}">&#x1F517;</a>
-        <span class="float-right">
+        <span class="float-right poll-badges">
           {% if not form.instance.is_published %}<span class="badge badge-warning">Unsichtbar</span> {% endif %}
-          {% if form.user_voted %}<span class="badge badge-info">Abgestimmt</span> {% endif %}
+          {% if form.user_voted %}<span class="badge badge-info success-badge">Abgestimmt</span> {% endif %}
           {% if can_change %}<a href="{% url 'admin:poll_poll_change' form.instance.id %}"><span class="badge badge-danger">Bearbeiten</span></a>{% endif %}
           {% if can_change or can_export %}<a href="{% url 'poll:export_raw' form.instance.id %}"><span class="badge badge-success">
             {% if can_export %}Export (komplett){% else %}Export (anonym){% endif %}
@@ -123,7 +123,12 @@
             {% csrf_token %}
             {% bootstrap_form form layout='inline' %}
             {% if can_vote and poll_collection.is_active and form.instance.is_published  and not print_mode %}
-              {% bootstrap_button "Abstimmen" button_type="submit" button_class="btn-info" %}
+            {% if form.user_voted %}
+              {% bootstrap_button "Abstimmen" button_type="submit" button_class="btn-success submit-button" %}
+            {% else %}
+              {% bootstrap_button "Abstimmen" button_type="submit" button_class="btn-info" extra_classes="submit-button" %}
+            {% endif %}
+            {% bootstrap_button "Stimme zurückziehen" button_type="reset" button_class="btn-warning" extra_classes="retract-button" %}
             {% endif %}
             <input type="hidden" name="next" value="{{ next }}?last_voted={{form.instance.id}}&tag={{search_tag}}&q={{search_q}}#poll{{form.instance.id}}" />
           </form>

--- a/poll/templates/poll/view.html
+++ b/poll/templates/poll/view.html
@@ -88,6 +88,7 @@
 
 {% for form in poll_forms %}
   <div class="question-card card card-light-bg mb-3 border {% if form.user_voted %}border-success{% endif %}"
+       data-id="{{ form.instance.pk }}"
        data-taglist="{{ form.tags|join:' ' }}"
        data-description="{{ form.instance.description }}"
        data-question="{{ form.instance.question }}"

--- a/poll/views.py
+++ b/poll/views.py
@@ -80,12 +80,8 @@ def poll_collection_view(request, poll_collection_id):
 
         form = PollForm(instance=p, user=request.user)
 
-        if search_tag:
-            if search_tag == 'Unbeantwortet':
-                if form.user_voted:
-                    continue
-            elif search_tag not in p.tags.names():
-                continue
+        if search_tag and search_tag not in form.tags:
+            continue
 
         if search_p and int(search_p) != p.pk:
             continue

--- a/poll/views.py
+++ b/poll/views.py
@@ -58,11 +58,6 @@ def poll_collection_view(request, poll_collection_id):
     for p in Poll.objects.filter(poll_collection=pc):
         available_tags.update(p.tags.names())
 
-    if set(terms) & available_tags:
-        search_tag = list(set(terms) & available_tags)[0]
-        terms.remove(search_tag)
-        search_q = " ".join(terms)
-
     poll_forms = []
     number = 1
     for p in Poll.objects.filter(poll_collection=pc).order_by('is_published', 'position', 'id'):
@@ -79,19 +74,6 @@ def poll_collection_view(request, poll_collection_id):
                 continue
 
         form = PollForm(instance=p, user=request.user)
-
-        if search_tag and search_tag not in form.tags:
-            continue
-
-        if search_p and int(search_p) != p.pk:
-            continue
-
-        if search_q:
-            for term in terms:
-                if term in (p.question + p.description):
-                    break
-            else:
-                continue
 
         poll_forms.append(form)
 


### PR DESCRIPTION
Mir ist aufgefallen, dass das Filtern durch Tags oder die Suche nach wie vor zu einem Page Reload führt (und damit die Eingaben löscht).

Mit diesem PR wird das Filtern client-seitig umgesetzt, aber so, dass die URL-Parameter nach wie vor verwendet (und auch gesetzt) werden (d.h. wenn man eine gefilterte Umfrage per URL verschicken will, geht das).

#2  sollte idealerweise vorher gemergt werden, da diese Änderungen darauf aufsetzen (es passiert aber auch nichts schlimmes, wenn du den PR zuerst mergst; gibt allenfalls einen zusäztlichen Merge Commit).